### PR TITLE
feat(chat): improve chat UX with smooth lazy loading, bubble width, and dupe fix

### DIFF
--- a/src/lib/chat/chatService.ts
+++ b/src/lib/chat/chatService.ts
@@ -13,14 +13,23 @@ export class ChatService {
     return data.id;
   }
 
-  static async getMessages(roomId: string, limit = 50): Promise<Message[]> {
+  static async getMessages(
+    roomId: string,
+    limit = 10,
+    before?: string // ISO string of created_at
+  ): Promise<Message[]> {
+    console.log("[ChatService.getMessages] params:", { roomId, limit, before });
     try {
-      const { data, error } = await supabase
+      let query = supabase
         .from("messages")
         .select("*")
         .eq("room_id", roomId)
         .order("created_at", { ascending: false })
         .limit(limit);
+      if (before) {
+        query = query.lt("created_at", before);
+      }
+      const { data, error } = await query;
       if (error) {
         console.error("Error fetching messages:", error);
         return [];


### PR DESCRIPTION
### Code Changes:
- Implement smooth scroll position restoration after loading older messages (WhatsApp-style lazy loading)
- Prevent horizontal scroll and ensure chat bubbles never touch chat room border
- Limit chat bubble max width to min(70vw, 400px) for better readability on long messages
- Prevent duplicate messages when paginating older messages
- Show "Load Older Messages" button only if container can't scroll (pagination always 10 per batch)
- Refactor scroll and loading logic for a more natural chat experience